### PR TITLE
Added ability to have a custom hostname and port when running web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # ModernREST
 
 Minimal JakartaEE 9 / Jersey 3 / Jetty 11 REST webapp with sessions and static files.
+
+
+### Running Configuration
+
+- You can use these extra configuration options when running the web server to allow to bind to different ports in your system.
+- **Example:**
+  - `java -Dport=8032 -Dhost=0.0.0.0 -jar target/ModernREST.jar src/main/resources`
+  - This will run the project on port `8032` and accessible from within your network using `0.0.0.0`.
+
+| Option   | Description                                          | Default   |
+|----------|------------------------------------------------------|-----------|
+| **port** | The port number to run the web server of.            | 8080      |
+| **host** | The hostname to be used when running the web server. | 127.0.0.1 |
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,21 @@
 
 Minimal JakartaEE 9 / Jersey 3 / Jetty 11 REST webapp with sessions and static files.
 
-```
+## Build and run the Web Server
+
+```shell
 mvn clean package
 java -jar target/ModernREST.jar src/main/resources
 ```
+
+### Web Server Running Configuration
+
+- You can use these extra configuration options when running the web server to allow to bind to different ports in your system.
+- **Example:**
+  - `java -Dport=8032 -Dhost=0.0.0.0 -jar target/ModernREST.jar src/main/resources`
+  - This will run the project on port `8032` and accessible from within your network using `0.0.0.0`.
+
+| Option   | Description                                          | Default   |
+|----------|------------------------------------------------------|-----------|
+| **port** | The port number to run the web server of.            | 8080      |
+| **host** | The hostname to be used when running the web server. | 127.0.0.1 |

--- a/src/main/java/com/chrisnewland/modernrest/webapp/WebServer.java
+++ b/src/main/java/com/chrisnewland/modernrest/webapp/WebServer.java
@@ -30,10 +30,9 @@ public class WebServer
 			System.exit(-1);
 		}
 
+		// Use a custom defined port and hostname
 		int port = Integer.parseInt(System.getProperty("port", "8080"));
 		String hostname = System.getProperty("host", "127.0.0.1");
-
-		System.out.println("Port: " + port + " host: " + hostname);
 
 		Server server = new Server(new InetSocketAddress(hostname, port));
 

--- a/src/main/java/com/chrisnewland/modernrest/webapp/WebServer.java
+++ b/src/main/java/com/chrisnewland/modernrest/webapp/WebServer.java
@@ -30,7 +30,12 @@ public class WebServer
 			System.exit(-1);
 		}
 
-		Server server = new Server(new InetSocketAddress("127.0.0.1", 8080));
+		int port = Integer.parseInt(System.getProperty("port", "8080"));
+		String hostname = System.getProperty("host", "127.0.0.1");
+
+		System.out.println("Port: " + port + " host: " + hostname);
+
+		Server server = new Server(new InetSocketAddress(hostname, port));
 
 		ServletContextHandler servletContextHandler = new ServletContextHandler(server, "/", ServletContextHandler.SESSIONS);
 

--- a/src/main/java/com/chrisnewland/modernrest/webapp/service/IndexService.java
+++ b/src/main/java/com/chrisnewland/modernrest/webapp/service/IndexService.java
@@ -12,6 +12,6 @@ public class IndexService
 	@Produces(MediaType.TEXT_HTML)
 	public String index()
 	{
-		return "<html><head><link rel=\"stylesheet\" type=\"text/css\" href=\"/static/style.css\"></head><body><h1>Test</h1></body></html>";
+		return "<html><head><link rel=\"stylesheet\" type=\"text/css\" href=\"/static/style.css\"></head><body><h1>It works!</h1></body></html>";
 	}
 }


### PR DESCRIPTION
This will allow for the users to set their own hostname and port numbers when running the web server to avoid port binding conflicts in their system.

Instructions have also been added to README.md